### PR TITLE
#163382819 Implement feedback on ui

### DIFF
--- a/UI/css/form.css
+++ b/UI/css/form.css
@@ -1,7 +1,7 @@
 .form {
     margin: 1rem auto;
-    padding: 1rem 4rem;
-    max-width: 480px;
+    padding: 1rem .5rem;
+    max-width: 45vw;
 }
 
 .input-group {
@@ -21,7 +21,7 @@ label {
 select,
 textarea {
     margin: .5rem 0;
-    padding: .5rem 1rem;
+    padding: 1rem;
     display: block;
     width: 100%;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, .4);
@@ -32,4 +32,11 @@ textarea {
 
 .form-paragraph {
     text-align: center;
+}
+
+@media (max-width: 768px) {
+    .form {
+        max-width: 90vw;
+        padding: 1rem;
+    }
 }

--- a/UI/css/modal.css
+++ b/UI/css/modal.css
@@ -63,5 +63,5 @@
 }
 
 .input-radio:checked~.flex-item {
-    border: 1rem solid var(--color-secondary);
+    border: .4rem solid var(--color-secondary);
 }

--- a/UI/css/utilities.css
+++ b/UI/css/utilities.css
@@ -6,6 +6,10 @@
   color: var(--color-white) !important;
 }
 
+.u-black {
+  color: var(--color-black) !important;
+}
+
 .active {
   opacity: 1;
   border-bottom: 1px solid var(--color-white)

--- a/UI/index.html
+++ b/UI/index.html
@@ -218,12 +218,14 @@
       <h2 class="secondary-heading">Feel Free to Send us a Message</h2>
       <p class="secondary-heading--small">...we would be happy to hear from you</p>
       <form action="#" class="form">
-        <div class="input-group"><label for="name">Name</label><input name="name" class="input" id="name" type="text"></div>
-        <div class="input-group"><label for="email">Email</label><input name="email" class="input" id="email" type="text"></div>
-        <div class="input-group"><label for="subject">Subject</label><input name="subject" class="input" id="subject"
+        <div class="input-group"><label class="u-black" for="name">Name</label><input name="name" class="input" id="name"
             type="text"></div>
-        <div class="input-group"><label for="subject">Description</label><textarea name="description" id="description"
-            rows="10"></textarea></div>
+        <div class="input-group"><label class="u-black" for="email">Email</label><input name="email" class="input" id="email"
+            type="text"></div>
+        <div class="input-group"><label class="u-black" for="subject">Subject</label><input name="subject" class="input"
+            id="subject" type="text"></div>
+        <div class="input-group"><label class="u-black" for="subject">Description</label><textarea name="description"
+            id="description" rows="10"></textarea></div>
         <div class="input-group">
           <input class="button button--alt" type="submit" value="Send">
         </div>


### PR DESCRIPTION
#### What does this PR do?
This PR implements design feedbacks on UI templates

#### Description of Task to be completed?
- make labels on the contact form visible
- reduce border width on modal cards when selected.
- increase the width and padding of form fields

#### How should this be manually tested?
- Clone this repository 
- Checkout branch `ch-implement-feedback-ui-163382819`  
- cd into UI folder and open index.html with any modern browser

#### What are the relevant pivotal tracker stories?
[#163382819](https://www.pivotaltracker.com/story/show/163382819)

#### Screenshots
- make labels on the contact form visible
before
![politico-feel-free-b4](https://user-images.githubusercontent.com/12853775/51582994-c2b13380-1ece-11e9-886d-f52b22b6016e.JPG)

after
![politico-feel-free-after](https://user-images.githubusercontent.com/12853775/51583061-fb510d00-1ece-11e9-9233-c9167e3f1319.JPG)

- reduce border width on modal cards when selected.
before
![politico-modal-item-border-b4](https://user-images.githubusercontent.com/12853775/51582993-c2b13380-1ece-11e9-86bf-674b432429e7.JPG)
after
![politico-modal-item-border-after](https://user-images.githubusercontent.com/12853775/51582992-c2189d00-1ece-11e9-97e4-8568a70563b7.JPG)

- increase the width and padding of form fields
before
![politico-intent-to-run-b4](https://user-images.githubusercontent.com/12853775/51583142-6ac6fc80-1ecf-11e9-9440-fccb10bae285.JPG)

after
![politico-intent-to-run-after](https://user-images.githubusercontent.com/12853775/51582989-c2189d00-1ece-11e9-8b92-599e3a2930e9.JPG)