### PR TITLE
#163507069 Implement create party:

### DIFF
--- a/server/controllers/parties.js
+++ b/server/controllers/parties.js
@@ -1,70 +1,25 @@
-import partiesData from '../models/parties';
+import Query from '../helpers/Query';
 
 class PartyController {
-  static create(req, res) {
-    const party = {
-      id: partiesData.length + 1,
-      name: res.locals.partyName,
-      hqAddress: res.locals.address,
-      logoUrl: res.locals.logo,
-    };
-    partiesData.push(party);
-    return res.status(201).send({
-      status: 201,
-      data: [
-        {
-          id: party.id,
-          name: party.name,
-          logoUrl: party.logoUrl,
-          hqAddress: party.hqAddress,
-        },
-      ],
-    });
-  }
-
-  static getAll(req, res) {
-    return res.status(200).send({
-      status: 200,
-      data: partiesData,
-    });
-  }
-
-  static getOne(req, res) {
-    const id = Number(req.params.id);
-    const party = partiesData.find(e => e.id === id);
-    return res.status(200).send({
-      status: 200,
-      data: [party],
-    });
-  }
-
-  static patchName(req, res) {
-    const id = Number(req.params.id);
-    const partyIndex = partiesData.findIndex(party => party.id === id);
-    partiesData[partyIndex].name = req.body.name;
-    return res.status(200).send({
-      status: 200,
-      data: [
-        {
-          id,
-          name: partiesData[partyIndex].name,
-        },
-      ],
-    });
-  }
-
-  static delete(req, res) {
-    const id = Number(req.params.id);
-    const partyIndex = partiesData.findIndex(party => party.id === id);
-    const party = partiesData.splice(partyIndex, 1);
-    return res.status(200).send({
-      status: 200,
-      data: [
-        {
-          message: `${party[0].name} deleted`,
-        },
-      ],
+  static async create(req, res) {
+    const values = [res.locals.partyName, res.locals.symbol, res.locals.address, res.locals.image];
+    const { rows } = await Query.createParty('parties', values);
+    if (rows) {
+      return res.status(201).send({
+        status: 201,
+        data: [
+          {
+            id: rows[0].id,
+            name: rows[0].name,
+          },
+        ],
+      });
+    }
+    return res.status(500).send({
+      status: 500,
+      error: 'Internal server Error',
     });
   }
 }
+
 export default PartyController;

--- a/server/helpers/Query.js
+++ b/server/helpers/Query.js
@@ -19,9 +19,9 @@ class Query {
     }
   }
 
-  static async checkUserInfoExist(userInfo) {
+  static async checkDuplicate(table, field, value) {
     try {
-      const result = await db.query('SELECT email FROM users WHERE email = $1', userInfo);
+      const result = await db.query(`SELECT ${field} FROM ${table} WHERE ${field} = $1`, value);
       return result;
     } catch (err) {
       return err;
@@ -34,6 +34,24 @@ class Query {
       return result;
     } catch (error) {
       return undefined;
+    }
+  }
+
+  static async createParty(table, userInfo) {
+    const text = `INSERT INTO ${table}(
+        name,
+        symbol,
+        hq_address,
+        logo_url
+      )
+      VALUES($1, $2, $3, $4)
+      returning id, name`;
+    try {
+      const result = await db.query(text, userInfo);
+      return result;
+    } catch (error) {
+      console.log(error);
+      return error;
     }
   }
 }

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -30,4 +30,13 @@ const generateToken = id => {
   return token;
 };
 
-export { joinStrings, hashPassword, comparePassword, splitName, generateToken };
+const getSymbol = str =>
+  str
+    .toLowerCase()
+    .split(' ')
+    .filter(e => e !== 'of' && e !== 'and' && e !== 'for')
+    .map(e => e[0])
+    .join('')
+    .toUpperCase();
+
+export { joinStrings, hashPassword, comparePassword, splitName, generateToken, getSymbol };

--- a/server/middlewares/emailExist.js
+++ b/server/middlewares/emailExist.js
@@ -1,7 +1,7 @@
-import QueryHelpers from '../helpers/Query';
+import Query from '../helpers/Query';
 
 const userInfoExists = async (req, res, next) => {
-  const { rows } = await QueryHelpers.checkUserInfoExist([req.body.email]);
+  const { rows } = await Query.checkDuplicate('users', 'email', [res.locals.email]);
   if (rows[0]) {
     return res.status(409).send({
       status: 409,

--- a/server/middlewares/isEmpty.js
+++ b/server/middlewares/isEmpty.js
@@ -31,7 +31,7 @@ const isEmpty = (req, res, next) => {
       });
     }
   } else {
-    const endpointRoot = req.url.split('/')[1];
+    const endpointRoot = req.originalUrl.split('/')[3];
     if (endpointRoot === 'offices') error = populateError(req, 'name', 'type');
     else if (endpointRoot === 'parties') error = populateError(req, 'name', 'hqAddress');
     else {

--- a/server/middlewares/justAdmin.js
+++ b/server/middlewares/justAdmin.js
@@ -1,0 +1,14 @@
+import db from '../models/db';
+
+const justAdmin = async (req, res, next) => {
+  const { rows } = await db.query(`SELECT is_admin FROM users WHERE id = $1`, [res.locals.user.id]);
+  if (rows[0].is_admin === true) {
+    return next();
+  }
+  return res.status(403).send({
+    status: 403,
+    error: 'You are not allowed to access this route',
+  });
+};
+
+export default justAdmin;

--- a/server/middlewares/partySymbolExists.js
+++ b/server/middlewares/partySymbolExists.js
@@ -1,0 +1,18 @@
+import Query from '../helpers/Query';
+import { getSymbol } from '../helpers';
+
+const partySymbolExists = async (req, res, next) => {
+  res.locals.symbol = getSymbol(res.locals.partyName);
+  const { rows } = await Query.checkDuplicate('parties', 'symbol', [res.locals.symbol]);
+  if (rows[0]) {
+    return res.status(409).send({
+      status: 409,
+      error: `Party acronym of ${
+        rows[0].symbol
+      } already exist. Please choose another name with different accronym`,
+    });
+  }
+  return next();
+};
+
+export default partySymbolExists;

--- a/server/middlewares/verifyToken.js
+++ b/server/middlewares/verifyToken.js
@@ -1,0 +1,23 @@
+import jwt from 'jsonwebtoken';
+
+const verifyToken = async (req, res, next) => {
+  const token = req.headers['x-access-token'];
+  if (!token) {
+    return res.status(401).send({
+      status: 401,
+      error: 'You need a token to access this route',
+    });
+  }
+  try {
+    const decoded = await jwt.verify(token, process.env.SECRET);
+    res.locals.user = { id: decoded.userId };
+  } catch (error) {
+    return res.status(401).send({
+      status: 401,
+      error: 'Invalid token',
+    });
+  }
+  return next();
+};
+
+export default verifyToken;

--- a/server/routes/parties.js
+++ b/server/routes/parties.js
@@ -2,16 +2,24 @@ import { Router } from 'express';
 import isEmpty from '../middlewares/isEmpty';
 import validateHqAddress from '../middlewares/validateHqAddress';
 import validateName from '../middlewares/validateName';
-import validateID from '../middlewares/validateID';
 import uploadlogo from '../middlewares/uploadLogo';
+import partySymbolExists from '../middlewares/partySymbolExists';
 import PartyController from '../controllers/parties';
+import verifyToken from '../middlewares/verifyToken';
+import justAdmin from '../middlewares/justAdmin';
 
 const parties = Router();
 
-parties.post('/', uploadlogo, isEmpty, validateName, validateHqAddress, PartyController.create);
-parties.get('/', PartyController.getAll);
-parties.get('/:id', validateID, PartyController.getOne);
-parties.patch('/:id/name', validateID, isEmpty, validateName, PartyController.patchName);
-parties.delete('/:id', validateID, PartyController.delete);
+parties.post(
+  '/',
+  verifyToken,
+  justAdmin,
+  uploadlogo,
+  isEmpty,
+  validateName,
+  validateHqAddress,
+  partySymbolExists,
+  PartyController.create,
+);
 
 export default parties;

--- a/server/tests/party.test.js
+++ b/server/tests/party.test.js
@@ -1,0 +1,151 @@
+import chai from 'chai';
+import { describe, it, before } from 'mocha';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import dropTables from '../models/dropTables';
+import createTables from '../models/createTables';
+import seedDb from '../models/seed/seedDb';
+import 'idempotent-babel-polyfill';
+
+const { expect } = chai;
+
+chai.use(chaiHttp);
+
+const tokenAdmin =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTU0ODk4NDU3MSwiZXhwIjoxNTQ5NTg5MzcxfQ.ZIDqiLemXgtVL6kIz-XzzJMr1Q4RDbpnS0Rc6QO2rL4';
+const tokenUser =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsImlhdCI6MTU0ODk4NDc3NywiZXhwIjoxNTQ5NTg5NTc3fQ.V1UuCiEhoTjLHM_szV4-2S1fAKCZZEiVpZdEEoSIUcs';
+
+describe('Parties Route', () => {
+  before(async () => {
+    await dropTables();
+    await createTables();
+    await seedDb();
+  });
+
+  describe('POST /parties - Create Party', () => {
+    it('should not create when user is not logged in', async () => {
+      const res = await chai
+        .request(app)
+        .post('/api/v1/parties')
+        .type('form')
+        .field('name', 'All Progressives Congress')
+        .field('hqAddress', 'APC National Secretariat')
+        .attach('logoUrl', './UI/img/img_3.jpg', 'img_3.jpg');
+      expect(res.status).to.equal(401);
+      expect(res.body.error).to.be.a('string');
+    });
+    it('should not create when user provides invalid token', async () => {
+      const res = await chai
+        .request(app)
+        .post('/api/v1/parties')
+        .set('x-access-token', 'justarandomstring')
+        .type('form')
+        .field('name', 'All Progressives Congress')
+        .field('hqAddress', 'APC National Secretariat')
+        .attach('logoUrl', './UI/img/img_3.jpg', 'img_3.jpg');
+      expect(res.status).to.equal(401);
+      expect(res.body.error).to.be.a('string');
+    });
+    it('should create when user is an admin', async () => {
+      const res = await chai
+        .request(app)
+        .post('/api/v1/parties')
+        .set('x-access-token', tokenAdmin)
+        .type('form')
+        .field('name', 'All Progressives Jongress')
+        .field('hqAddress', 'APC National Secretariat')
+        .attach('logoUrl', './UI/img/img_3.jpg', 'img_3.jpg');
+      expect(res.status).to.equal(201);
+    });
+    it('should not create a new party if  name is empty', done => {
+      chai
+        .request(app)
+        .post('/api/v1/parties')
+        .set('x-access-token', tokenAdmin)
+        .type('form')
+        .field('name', '')
+        .field('hqAddress', 'APC National Secretariat')
+        .attach('logoUrl', './UI/img/img_3.jpg', 'img_3.jpg')
+        .then(res => {
+          expect(res.status).to.equal(400);
+          done();
+        });
+    });
+
+    it('should not create a new party if hqAddress is empty', done => {
+      chai
+        .request(app)
+        .post('/api/v1/parties')
+        .set('x-access-token', tokenAdmin)
+        .type('form')
+        .field('name', 'All Progressives Congress')
+        .field('hqAddress', '')
+        .attach('logoUrl', './UI/img/img_3.jpg', 'img_3.jpg')
+        .then(res => {
+          expect(res.status).to.equal(400);
+          done();
+        });
+    });
+
+    it('should not create a new party if logoUrl is empty', done => {
+      chai
+        .request(app)
+        .post('/api/v1/parties')
+        .set('x-access-token', tokenAdmin)
+        .type('form')
+        .field('name', 'All Progressives Congress')
+        .field('hqAddress', 'APC National Secretariat')
+        .attach('logoUrl', '', '')
+        .then(res => {
+          expect(res.status).to.equal(400);
+          done();
+        });
+    });
+
+    it('should not create a new party if hqAddress is invalid', done => {
+      chai
+        .request(app)
+        .post('/api/v1/parties')
+        .set('x-access-token', tokenAdmin)
+        .type('form')
+        .field('name', 'All Progressives Congress')
+        .field('hqAddress', '')
+        .attach('logoUrl', './UI/img/img_3.jpg', 'img_3.jpg')
+        .then(res => {
+          expect(res.status).to.equal(400);
+          done();
+        });
+    });
+
+    it('should not create a new party if name is too short', done => {
+      chai
+        .request(app)
+        .post('/api/v1/parties')
+        .set('x-access-token', tokenAdmin)
+        .type('form')
+        .field('name', 'All')
+        .field('hqAddress', 'APC National Secretariat')
+        .attach('logoUrl', './UI/img/img_3.jpg', 'img_3.jpg')
+        .then(res => {
+          expect(res.status).to.equal(400);
+          done();
+        });
+    });
+
+    it('should not create a new party if logoUrl is not valid', done => {
+      chai
+        .request(app)
+        .post('/api/v1/parties')
+        .set('x-access-token', tokenAdmin)
+        .type('form')
+        .field('name', 'All Progressives Congress')
+        .field('hqAddress', 'APC National Secretariat')
+        .attach('logoUrl', './UI/index.html', 'index.html')
+        .then(res => {
+          expect(res.status).to.equal(400);
+          done();
+        });
+    });
+  });
+});

--- a/server/tests/party.test.js
+++ b/server/tests/party.test.js
@@ -11,16 +11,24 @@ const { expect } = chai;
 
 chai.use(chaiHttp);
 
-const tokenAdmin =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTU0ODk4NDU3MSwiZXhwIjoxNTQ5NTg5MzcxfQ.ZIDqiLemXgtVL6kIz-XzzJMr1Q4RDbpnS0Rc6QO2rL4';
-const tokenUser =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjMsImlhdCI6MTU0ODk4NDc3NywiZXhwIjoxNTQ5NTg5NTc3fQ.V1UuCiEhoTjLHM_szV4-2S1fAKCZZEiVpZdEEoSIUcs';
 
 describe('Parties Route', () => {
+  let tokenAdmin;
+
   before(async () => {
     await dropTables();
     await createTables();
     await seedDb();
+    const result = await chai
+      .request(app)
+      .post('/api/v1/auth/login')
+      .send({
+        email: 'haywhyze@hotmail.com',
+        password: process.env.ADMIN_PASSWORD,
+      });
+    console.log(result.body.data[0].token);
+
+    tokenAdmin = result.body.data[0].token;
   });
 
   describe('POST /parties - Create Party', () => {


### PR DESCRIPTION
#### What does this PR do?
Implement create a party to persist with data on the database
#### Description of Task to be completed?
- add a helper to get an acronym from the party name
- add justAdmin middleware to restrict access to the route.
- add middleware to avoid duplicate party acronyms.
- add verifyToken middleware to verify users
- add create party controller to create a party that persists on the database
- add the middlewares and the controller to the parties router.
#### How should this be manually tested?
- clone this repository by executing `git clone https://github.com/haywhyze/politico.git`
- cd to the cloned local repository `cd politico`
- run `git checkout ft-create-party-db-163507069`
- install all dependencies by running `npm install`
- start the server with `npm start`
- when the server is up, you can test using Postman or any other related service.
- On Postman, test by sending the following values to `/api/v1/parties` through a POST request:
```
logoUrl,
name,
hqAddress
```
#### What are the relevant pivotal tracker stories?
[#163507069](https://www.pivotaltracker.com/story/show/163507069)
